### PR TITLE
Fix numbered step_id lists when count exceeds 9 entries

### DIFF
--- a/sphinxcontrib/autosaltsls/templates/sls.rst_t
+++ b/sphinxcontrib/autosaltsls/templates/sls.rst_t
@@ -45,7 +45,7 @@ Steps
 {%-       else %}
 {{ loop.index }}. {{ entry.summary }}
 {%-       endif %}
-    {{ entry.content }}
+       {{ entry.content }}
 {%-     endfor %}
 {%-   endif %}
 


### PR DESCRIPTION
Increased indentation for step_id summary lines to fix render failure when numbered entry exceeds 9