### PR TITLE
Change os.mkdir to os.makedirs

### DIFF
--- a/sphinxcontrib/autosaltsls/mapper.py
+++ b/sphinxcontrib/autosaltsls/mapper.py
@@ -362,7 +362,7 @@ class AutoSaltSLSMapper(object):
             )
 
             try:
-                os.mkdir(self.build_root)
+                os.makedirs(self.build_root)
             except PermissionError:
                 raise ExtensionError(
                     "Could not create '{0}, permission denied".format(self.build_root)


### PR DESCRIPTION
Hi,

At first thanks for creating this, very helpful to document our salt states.

When specifying autosaltsls_build_root to multiple levels of directories (e.g. ./main/sub) of which they all do not exist yet, it will not be able to create this.